### PR TITLE
FIX: opened cell closes upon a tap on another cell. A new cell opens …

### DIFF
--- a/bobikApp/TableVC.swift
+++ b/bobikApp/TableVC.swift
@@ -56,13 +56,16 @@ class TableVC: UITableViewController {
             let indexPath = IndexPath(row: lastTappeCellIdex, section: 0)
             if let lastTappedCell = tableView.cellForRow(at: indexPath) as? CustomCell {
                 lastTappedCell.bioLabel.text = "tap to expand -->"
+                tableView.beginUpdates()
+                tableView.endUpdates()
             }
+        } else {
+            // Updates newly tapped cell
+            guard let tappedCell = tableView.cellForRow(at: indexPath) as? CustomCell else {return}
+            tappedCell.bioLabel.text = people[indexPath.row].bio
+            tableView.beginUpdates()
+            tableView.endUpdates()
+            openedCellStatus[indexPath.row] = true
         }
-        // Updates newly tapped cell
-        guard let tappedCell = tableView.cellForRow(at: indexPath) as? CustomCell else {return}
-        tappedCell.bioLabel.text = people[indexPath.row].bio
-        tableView.beginUpdates()
-        tableView.endUpdates()
-        openedCellStatus[indexPath.row] = true
     }
 }


### PR DESCRIPTION
Hi Bob. This pull request contains a fix to the cell-opnning logic. It used to be that the tap on a cell would close any opened cell and open the tapped cell immediately. That was wrong. Now, a tap on a cell closes any other opened cell. Then when there are no opened cells, a tap on a cell opens it